### PR TITLE
Add a non mappable article

### DIFF
--- a/data/wikipedia/non_mappable/articles
+++ b/data/wikipedia/non_mappable/articles
@@ -49,7 +49,7 @@ Anagrafe nazionale studenti
 Angelo custode (Domenico Antonio Vaccaro)
 Angelo reggicandelabro
 Angelo Rocca
-Angolo di Pedavena 	
+Angolo di Pedavena
 Annales Cavenses
 Anna Maria Luisa de' Medici
 Annunciazione (Antonello da Messina)
@@ -495,7 +495,7 @@ Elettromotrice 1-6 MetroGenova
 Elettromotrice T.67 A
 Elettromotrici ACOTRAL MA 100
 Elettromotrici AMT 01-06
-Elettromotrici AMT 01-06 	
+Elettromotrici AMT 01-06
 Elettromotrici AMT 11-22
 Elettromotrici COTRAL MA 200
 Elettromotrici della linea 1 della metropolitana di Napoli
@@ -626,7 +626,7 @@ Houston Galleria
 I Cavernicoli
 Idroscali in Italia
 Idroscalo di Siracusa
-I fuochi sacri 	
+I fuochi sacri
 III Biennale di Monza
 Il male oscuro (romanzo)
 Il processo dei Consoli
@@ -651,7 +651,7 @@ Irredentismo italiano in Svizzera
 Isabella de' Medici
 Isaia (Fra Bartolomeo)
 Ischia Film Festival
-Ischia (vino) 	
+Ischia (vino)
 Isole della Sicilia
 Isole dell'Italia
 Isole d'Italia per popolazione
@@ -723,7 +723,7 @@ Lorenzo il Vecchio
 Lorium
 Ludovico Bonaccioli
 Luigi Pigorini
-Luna sospesa bianca 	
+Luna sospesa bianca
 Luoghi di culto di Ostia antica
 Macchine anatomiche
 Maddalena penitente (Desiderio da Settignano)
@@ -769,7 +769,7 @@ Martirio di san Sebastiano (Piero del Pollaiolo)
 MAS 15
 Mascarata
 Maternità (dipinto)
-Maternità (dipinto) 		
+Maternità (dipinto)
 Matrimonio mistico di santa Caterina d'Alessandria (Filippino Lippi)
 Mattias de' Medici
 Medmar
@@ -896,7 +896,7 @@ Padre padrone (romanzo)
 Pagamento del tributo
 Pala Barbadori
 Pala Barbarigo
-Pala Barbarigo 	
+Pala Barbarigo
 Pala Dei
 Pala dei Barcaioli
 Pala dei Disciplini
@@ -1372,7 +1372,7 @@ Università degli Studi "Guglielmo Marconi"
 Università degli Studi "Niccolò Cusano"
 Università in Italia
 Università presenti in Italia
-Università straniere in Toscana	Università della Toscana		
+Università straniere in Toscana	Università della Toscana
 Università telematica
 Università telematica Giustino Fortunato
 Università telematica internazionale UniNettuno
@@ -1446,3 +1446,4 @@ Zelanga
 Zio Feininger
 Zone umide italiane della lista di Ramsar
 Zuffa fra Pompeiani e Nocerini
+Aeroporto di Cirè


### PR DESCRIPTION
Aeroporto di Cirè https://it.wikipedia.org/wiki/Aeroporto_di_Cir%C3%A8
